### PR TITLE
fix: clickable links + HTML rendering in episode description

### DIFF
--- a/src/pages/[lang]/episodes/[slug].astro
+++ b/src/pages/[lang]/episodes/[slug].astro
@@ -10,6 +10,7 @@ import RelatedEpisodes from '../../../components/RelatedEpisodes.astro';
 import EpisodeNavigation from '../../../components/EpisodeNavigation.astro';
 import SimpleAudioPlayer from '../../../components/SimpleAudioPlayer.astro';
 import { getEpisodeBySlug, getGuestBySlug, getGuestUrl, getHostBySlug } from '../../../utils/content';
+import { renderEpisodeDescription } from '../../../utils/markdown';
 import type { Language } from '../../../types';
 
 export async function getStaticPaths() {
@@ -313,7 +314,7 @@ const getDateLocale = (lang: Language) => {
           <!-- Episode Description -->
           <div class="prose prose-lg dark:prose-invert max-w-none mb-lg content-spacing">
             <h2 class="text-2xl lg:text-3xl">{t.description}</h2>
-            <p style="white-space: pre-line;">{episode.data.description}</p>
+            <div style="white-space: pre-line;" set:html={renderEpisodeDescription(episode.data.description)} />
           </div>
 
           <!-- Guest(s) and Host(s) Section for Mobile -->

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,10 +4,10 @@
  */
 export function parseMarkdownLinks(text: string): string {
   if (!text) return '';
-  
+
   // Replace markdown links [text](url) with HTML links
   const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
-  
+
   return text.replace(linkPattern, (match, linkText, url) => {
     // Ensure the URL is valid and safe
     try {
@@ -25,4 +25,42 @@ export function parseMarkdownLinks(text: string): string {
     // Return original text if URL is invalid
     return match;
   });
+}
+
+/**
+ * Render an episode description that may mix plain text, markdown-style
+ * [text](url) links, bare URLs, and inline HTML (e.g. <a>, <ul>, <li>).
+ * Returns HTML safe to render with set:html.
+ */
+export function renderEpisodeDescription(text: string): string {
+  if (!text) return '';
+
+  const stash: string[] = [];
+  const mask = (match: string) => {
+    stash.push(match);
+    return `<\x00T${stash.length - 1}\x00>`;
+  };
+
+  // 1. Mask existing <a>...</a> blocks so their inner URLs aren't re-linked
+  let result = text.replace(/<a\b[^>]*>[\s\S]*?<\/a>/gi, mask);
+
+  // 2. Convert markdown [text](url) links to <a>, then mask those too
+  result = parseMarkdownLinks(result);
+  result = result.replace(/<a\b[^>]*>[\s\S]*?<\/a>/gi, mask);
+
+  // 3. Mask remaining real HTML tags. The "[^>\x00]" class skips placeholders.
+  result = result.replace(/<[^>\x00]+>/g, mask);
+
+  // 4. Auto-link bare URLs. "[^\s<]" stops the match at placeholder boundaries.
+  result = result.replace(/https?:\/\/[^\s<]+/g, (url) => {
+    const m = url.match(/^(.*?)([.,;!?:)\]"']*)$/);
+    const clean = (m && m[1]) || url;
+    const trail = (m && m[2]) || '';
+    return `<a href="${clean}" target="_blank" rel="noopener noreferrer" class="text-primary-600 dark:text-primary-300 hover:underline">${clean}</a>${trail}`;
+  });
+
+  // 5. Restore masked tokens
+  result = result.replace(/<\x00T(\d+)\x00>/g, (_, i) => stash[parseInt(i, 10)] ?? '');
+
+  return result;
 }

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { parseMarkdownLinks, renderEpisodeDescription } from '../../src/utils/markdown'
+
+describe('parseMarkdownLinks', () => {
+  it('returns empty string for empty input', () => {
+    expect(parseMarkdownLinks('')).toBe('')
+  })
+
+  it('converts [text](url) to anchor tags', () => {
+    const out = parseMarkdownLinks('See [example](https://example.com).')
+    expect(out).toContain('<a href="https://example.com"')
+    expect(out).toContain('>example</a>')
+    expect(out.endsWith('.')).toBe(true)
+  })
+
+  it('leaves plain text unchanged', () => {
+    expect(parseMarkdownLinks('plain text only')).toBe('plain text only')
+  })
+})
+
+describe('renderEpisodeDescription', () => {
+  it('returns empty string for empty input', () => {
+    expect(renderEpisodeDescription('')).toBe('')
+  })
+
+  it('auto-links bare URLs', () => {
+    const out = renderEpisodeDescription('Tickets: https://example.com/')
+    expect(out).toContain('<a href="https://example.com/"')
+    expect(out).toContain('target="_blank"')
+    expect(out).toContain('rel="noopener noreferrer"')
+  })
+
+  it('does not double-wrap URLs already inside anchor tags', () => {
+    const input = '<a href="https://example.com">https://example.com</a>'
+    const out = renderEpisodeDescription(input)
+    expect(out).toBe(input)
+    expect(out).not.toContain('<a href="https://example.com"><a')
+  })
+
+  it('passes inline HTML lists through unchanged', () => {
+    const input = '<ul>\n<li>foo</li>\n<li>https://x.com</li>\n</ul>'
+    const out = renderEpisodeDescription(input)
+    expect(out).toContain('<ul>')
+    expect(out).toContain('<li>foo</li>')
+    expect(out).toContain('<a href="https://x.com"')
+  })
+
+  it('converts markdown-style [text](url) links', () => {
+    const out = renderEpisodeDescription('See [example](https://example.com)')
+    expect(out).toContain('<a href="https://example.com"')
+    expect(out).toContain('>example</a>')
+  })
+
+  it('strips trailing punctuation outside the URL', () => {
+    const out = renderEpisodeDescription('See https://example.com.')
+    expect(out).toContain('<a href="https://example.com"')
+    expect(out).toContain('>https://example.com</a>.')
+  })
+
+  it('handles a mix of bare URLs and bullet lines', () => {
+    const input = 'Tickets: https://example.com/\n\nLinks:\n* https://a.com/\n* https://b.com/'
+    const out = renderEpisodeDescription(input)
+    expect(out).toContain('<a href="https://example.com/"')
+    expect(out).toContain('<a href="https://a.com/"')
+    expect(out).toContain('<a href="https://b.com/"')
+  })
+
+  it('handles HTML lists with nested anchors', () => {
+    const input = 'Links:\n<ul>\n<li><a href="https://x.com">https://x.com</a></li>\n</ul>'
+    const out = renderEpisodeDescription(input)
+    expect(out).toContain('<ul>')
+    expect(out).toContain('<a href="https://x.com">https://x.com</a>')
+    expect(out).not.toContain('<a href="https://x.com"><a')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes two bugs on episode pages where the `description` from frontmatter wasn't rendering as expected.

- **S6E3 (from-cro-to-axo):** description contains inline HTML (`<a>`, `<ul>`, `<li>`) — they were rendered as raw text on the page.
- **S6E4 (are-we-creating-ai-solutions):** description contains bare URLs — they were not clickable.

**Root cause** (`src/pages/[lang]/episodes/[slug].astro:316`):

```astro
<p style="white-space: pre-line;">{episode.data.description}</p>
```

`{...}` text interpolation escapes HTML, and `<p>` is also invalid as a parent for `<ul>`. Both bugs share that one line.

## Fix

- New helper `renderEpisodeDescription` in `src/utils/markdown.ts`:
  - masks existing `<a>...</a>` blocks (NUL-bracketed placeholders so they survive subsequent regex passes without collision)
  - runs `parseMarkdownLinks` for `[text](url)` markdown
  - masks remaining HTML tags
  - auto-links bare `https?://...` URLs, stripping trailing sentence punctuation
  - restores all masked tokens at the end
- Page switched to `<div set:html={renderEpisodeDescription(...)}>` — `<div>` because `<ul>` can't live inside `<p>`.

## Test Coverage

Added `tests/unit/markdown.test.ts` with **11 vitest cases** covering:

- empty input
- bare URL auto-linking (with `target="_blank"` + `rel="noopener noreferrer"`)
- no double-wrapping when `<a>` already exists
- `<ul>`/`<li>` HTML pass-through
- markdown `[text](url)` conversion
- trailing-punctuation handling (period stays outside the link)
- mixed plain-text + bullet list (S6E4-style)
- HTML list with nested anchors (S6E3-style)

All 11 pass.

## Pre-existing test failures (NOT caused by this PR)

Running the full vitest suite shows ~70 failing tests on `main` in unrelated areas: `simpleAudioManager`, `Breadcrumb`/`EpisodeCard`/`Header` a11y, `Navigation`, `brand-logos`. None touch `src/utils/markdown.ts` or `src/pages/[lang]/episodes/[slug].astro`. They predate this branch.

## Trust boundary

`set:html` rendering of `description` was already the intended path — the prior content fix in cc368e210 deliberately authored S6E3's description as HTML "to render clickable through set:html". Episode descriptions come from NocoDB-synced MDX (author-controlled), not public user input.

## Test plan

- [x] `npx vitest run tests/unit/markdown.test.ts` — 11/11 pass
- [ ] Visual check on `/en/episodes/are-we-creating-ai-solutions-or-just-chasing-problems/` — bare URLs are clickable
- [ ] Visual check on `/en/episodes/from-cro-to-axo-adapting-to-ai-in-digital-marketing/` — `<ul>`/`<li>`/`<a>` render as a real list, not source text

🤖 Generated with [Claude Code](https://claude.com/claude-code)